### PR TITLE
Extending the usage of the extension across more server links

### DIFF
--- a/browser-extension/background.ts
+++ b/browser-extension/background.ts
@@ -5,9 +5,32 @@ browser.pageAction.onClicked.addListener(function(tab: browser.tabs.Tab) {
 
 const filter = {
     urls: [
-        // TODO: Add all the servers 
         "https://training.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
-        "https://training.vri-research.com/index.php/admin/responses/sa/index/surveyid/*",
+        "https://training.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://opinion-insight.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinion-insight.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://research-opinions.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://research-opinions.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://opinions-survey.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinions-survey.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://p.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://p.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://m.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://m.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
     ],
 }
 

--- a/browser-extension/background.ts
+++ b/browser-extension/background.ts
@@ -20,9 +20,6 @@ const filter = {
         "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
 
-        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
-        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
-
         "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
 

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -16,7 +16,34 @@
 
   "content_scripts": [
     {
-      "matches": ["*://training.vri-research.com/*"],
+      "matches": [
+        "https://training.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://training.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://opinion-insight.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinion-insight.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://research-opinions.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://research-opinions.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://opinions-survey.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinions-survey.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://p.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://p.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://m.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://m.vri-research.com/index.php/admin/responses/sa/*/surveyid/*"
+      ],
       "js": ["test.js"]
     }
   ],

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -32,9 +32,6 @@
         "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
 
-        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
-        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
-
         "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
 

--- a/browser-extension/test.ts
+++ b/browser-extension/test.ts
@@ -40,10 +40,10 @@ function getSurveyIdFromURL(): string {
  */
 function getServerNameFromURL(): string {
     if (!location) return;
-
-    const startIdxInclusive = location.pathname.indexOf('//') + 2;
-    const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
-    return location.pathname.substring(startIdxInclusive, endIdxExclusive);
+    return location.hostname;
+    // const startIdxInclusive = location.pathname.indexOf('//') + 2;
+    // const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
+    // return location.pathname.substring(startIdxInclusive, endIdxExclusive);
 
 }
 

--- a/browser-extension/test.ts
+++ b/browser-extension/test.ts
@@ -26,13 +26,25 @@ function encodeArray(key: string, values: string[]): string {
 }
 
 /*
- * Retreive survey id from the current page's url.
+ * Retrieve survey id from the current page's url.
  */
 function getSurveyIdFromURL(): string {
     if (!location) return;
 
     const startIdx = location.pathname.lastIndexOf('/') + 1;
     return location.pathname.substring(startIdx);
+}
+
+/**
+ * Retrieve the server name from URL.
+ */
+function getServerNameFromURL(): string {
+    if (!location) return;
+
+    const startIdxInclusive = location.pathname.indexOf('//') + 2;
+    const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
+    return location.pathname.substring(startIdxInclusive, endIdxExclusive);
+
 }
 
 function getStaticPayloadValues(): string {
@@ -262,11 +274,17 @@ async function downloadFiles() {
         CSV_MCV = 'export-multichice-encoded'
     }
 
-    const server: string = "training.vri-research.com";
+    const server: string = getServerNameFromURL();
+    console.log("Server id: ", server);
+    if (!server) {
+        console.error("Cannot resolve server name");
+        return;
+    }
 
     const surveyId: string = getSurveyIdFromURL();
     if (!surveyId) {
         console.error("Cannot find survey id");
+        return;
     }
 
     let commonRequestPayload: string = await getRequestPayload(surveyId, server);

--- a/browser-extension/test.ts
+++ b/browser-extension/test.ts
@@ -41,10 +41,6 @@ function getSurveyIdFromURL(): string {
 function getServerNameFromURL(): string {
     if (!location) return;
     return location.hostname;
-    // const startIdxInclusive = location.pathname.indexOf('//') + 2;
-    // const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
-    // return location.pathname.substring(startIdxInclusive, endIdxExclusive);
-
 }
 
 function getStaticPayloadValues(): string {

--- a/dist/background.js
+++ b/dist/background.js
@@ -5,9 +5,24 @@ browser.pageAction.onClicked.addListener(function (tab) {
 });
 const filter = {
     urls: [
-        // TODO: Add all the servers 
         "https://training.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
-        "https://training.vri-research.com/index.php/admin/responses/sa/index/surveyid/*",
+        "https://training.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://opinion-insight.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinion-insight.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://research-opinions.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://research-opinions.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://opinions-survey.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinions-survey.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://p.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://p.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+        "https://m.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://m.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
     ],
 };
 browser.tabs.onUpdated.addListener((id, changeInfo, tab) => {

--- a/dist/background.js
+++ b/dist/background.js
@@ -15,8 +15,6 @@ const filter = {
         "https://opinions-survey.com/index.php/admin/responses/sa/*/surveyid/*",
         "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
-        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
-        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
         "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
         "https://p.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -16,7 +16,34 @@
 
   "content_scripts": [
     {
-      "matches": ["*://training.vri-research.com/*"],
+      "matches": [
+        "https://training.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://training.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://opinion-insight.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinion-insight.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://research-opinions.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://research-opinions.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://opinions-survey.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://opinions-survey.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://p.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://p.vri-research.com/index.php/admin/responses/sa/*/surveyid/*",
+
+        "https://m.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*",
+        "https://m.vri-research.com/index.php/admin/responses/sa/*/surveyid/*"
+      ],
       "js": ["test.js"]
     }
   ],

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -32,9 +32,6 @@
         "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
 
-        "https://insight-polls.com/index.php/admin/edispnew/sa/index/surveyid/*",
-        "https://insight-polls.com/index.php/admin/responses/sa/*/surveyid/*",
-
         "https://viewpointpoll.com/index.php/admin/edispnew/sa/index/surveyid/*",
         "https://viewpointpoll.com/index.php/admin/responses/sa/*/surveyid/*",
 

--- a/dist/test.js
+++ b/dist/test.js
@@ -37,9 +37,10 @@ function getSurveyIdFromURL() {
 function getServerNameFromURL() {
     if (!location)
         return;
-    const startIdxInclusive = location.pathname.indexOf('//') + 2;
-    const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
-    return location.pathname.substring(startIdxInclusive, endIdxExclusive);
+    return location.hostname;
+    // const startIdxInclusive = location.pathname.indexOf('//') + 2;
+    // const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
+    // return location.pathname.substring(startIdxInclusive, endIdxExclusive);
 }
 function getStaticPayloadValues() {
     let payload = '';

--- a/dist/test.js
+++ b/dist/test.js
@@ -23,13 +23,23 @@ function encodeArray(key, values) {
     }).join('&');
 }
 /*
- * Retreive survey id from the current page's url.
+ * Retrieve survey id from the current page's url.
  */
 function getSurveyIdFromURL() {
     if (!location)
         return;
     const startIdx = location.pathname.lastIndexOf('/') + 1;
     return location.pathname.substring(startIdx);
+}
+/**
+ * Retrieve the server name from URL.
+ */
+function getServerNameFromURL() {
+    if (!location)
+        return;
+    const startIdxInclusive = location.pathname.indexOf('//') + 2;
+    const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
+    return location.pathname.substring(startIdxInclusive, endIdxExclusive);
 }
 function getStaticPayloadValues() {
     let payload = '';
@@ -238,10 +248,16 @@ async function downloadFiles() {
         CSV_Types["CSV_HM"] = "export-heatmap-text";
         CSV_Types["CSV_MCV"] = "export-multichice-encoded";
     })(CSV_Types || (CSV_Types = {}));
-    const server = "training.vri-research.com";
+    const server = getServerNameFromURL();
+    console.log("Server id: ", server);
+    if (!server) {
+        console.error("Cannot resolve server name");
+        return;
+    }
     const surveyId = getSurveyIdFromURL();
     if (!surveyId) {
         console.error("Cannot find survey id");
+        return;
     }
     let commonRequestPayload = await getRequestPayload(surveyId, server);
     console.log("Download started!");

--- a/dist/test.js
+++ b/dist/test.js
@@ -38,9 +38,6 @@ function getServerNameFromURL() {
     if (!location)
         return;
     return location.hostname;
-    // const startIdxInclusive = location.pathname.indexOf('//') + 2;
-    // const endIdxExclusive = location.pathname.indexOf('/', startIdxInclusive);
-    // return location.pathname.substring(startIdxInclusive, endIdxExclusive);
 }
 function getStaticPayloadValues() {
     let payload = '';


### PR DESCRIPTION
This PR extends the page action button's visibility and file download functionality to additional server links. 

The following servers links are supported with this change:
1. training.vri-research.com (this was already supported)
2. opinion-insight.com
3. research-opinions.com
4. opinions-survey.com
5. insight-polls.com
6. viewpointpoll.com
7. p.vri-research.com
8. m.vri-research.com

Closes: #2 