### PR TITLE
Allow extension to work on remaining eligible servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # Download disposition files with one click
 
 - Click on the extension icon to initiate the download process.
-- Applicable URLs on which the download works:
-    - URL that contains valid server name (see below), and
-    - contains survey id.
+- URLs on which the download works:
+    - URL that contains valid **server name** (see below), and
+    - contains **survey id**.
 
-- Applicable server names:
+- Valid server names:
     1. `training.vri-research.com`
+    2. `opinion-insight.com`
+    3. `research-opinions.com`
+    4. `opinions-survey.com`
+    5. `insight-polls.com`
+    6. `viewpointpoll.com`
+    7. `p.vri-research.com`
+    8. `m.vri-research.com`
 
 - It downloads the following files:
     1. CSV (includes all responses): `results-survey{surveyId}.csv`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Download disposition files with one click
 
-- Adds a button on the right side of the address bar only one specific urls. The button allows to download the files by one click.
-- Applicable URLs on which the download button appears:
-    - Enhanced Dispositions: Segments page - `https://training.vri-research.com/index.php/admin/edispnew/sa/index/surveyid/*`
-    - Response summary page - `https://training.vri-research.com/index.php/admin/responses/sa/index/surveyid/*`
+- Click on the extension icon to initiate the download process.
+- Applicable URLs on which the download works:
+    - URL that contains valid server name (see below), and
+    - contains survey id.
+
+- Applicable server names:
+    1. `training.vri-research.com`
 
 - It downloads the following files:
     1. CSV (includes all responses): `results-survey{surveyId}.csv`

--- a/dist/background.js
+++ b/dist/background.js
@@ -5,23 +5,15 @@ browser.action.onClicked.addListener(async function (tab) {
     // Check if on the right tab to execute the process.
     const serverName = extractHostname(tab.url);
     const surveyId = extractSurveyId(tab.url);
-    const validServerNames = [
-        "training.vri-research.com",
-        "opinion-insight.com",
-        "research-opinions.com",
-        "opinions-survey.com",
-        "insight-polls.com",
-        "viewpointpoll.com",
-        "p.vri-research.com",
-        "m.vri-research.com",
-    ];
+    const validServerNames = browser.runtime.getManifest().host_permissions
+        .map(url => extractHostname(url));
     if (!serverName || !surveyId || !validServerNames.some(name => name === serverName)) {
         console.error("Wrong tab or you're the fastest in the west since you changed tabs so fast!");
         return;
     }
     try {
-        console.log("Download started!");
         let commonRequestPayload = await getRequestPayload(surveyId, serverName);
+        console.log("Download started!");
         const CSV_Types = [
             'csv',
             'export-rotation-orders',

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -19,7 +19,14 @@
     "cookies"
   ],
   "host_permissions": [
-    "https://training.vri-research.com/*"
+    "https://training.vri-research.com/*",
+    "https://opinion-insight.com/*",
+    "https://research-opinions.com/*",
+    "https://opinions-survey.com/*",
+    "https://insight-polls.com/*",
+    "https://viewpointpoll.com/*",
+    "https://p.vri-research.com/*",
+    "https://m.vri-research.com/*"
   ]
 }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,24 +4,17 @@ browser.action.onClicked.addListener(async function (tab: browser.tabs.Tab) {
     // Check if on the right tab to execute the process.
     const serverName: string = extractHostname(tab.url);
     const surveyId: string = extractSurveyId(tab.url);
-    const validServerNames = [
-        "training.vri-research.com",
-        "opinion-insight.com",
-        "research-opinions.com",
-        "opinions-survey.com",
-        "insight-polls.com",
-        "viewpointpoll.com",
-        "p.vri-research.com",
-        "m.vri-research.com",
-    ];
+    const validServerNames = browser.runtime.getManifest().host_permissions
+        .map(url => extractHostname(url));
+
     if (!serverName || !surveyId || !validServerNames.some(name => name===serverName) ) {
         console.error("Wrong tab or you're the fastest in the west since you changed tabs so fast!");
         return;
     }
 
     try {
-        console.log("Download started!");
         let commonRequestPayload: string = await getRequestPayload(surveyId, serverName);
+        console.log("Download started!");
         const CSV_Types: string[] = [
             'csv',
             'export-rotation-orders',

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,14 @@
     "cookies"
   ],
   "host_permissions": [
-    "https://training.vri-research.com/*"
+    "https://training.vri-research.com/*",
+    "https://opinion-insight.com/*",
+    "https://research-opinions.com/*",
+    "https://opinions-survey.com/*",
+    "https://insight-polls.com/*",
+    "https://viewpointpoll.com/*",
+    "https://p.vri-research.com/*",
+    "https://m.vri-research.com/*"
   ]
 }
 


### PR DESCRIPTION
This PR focuses on making the extension work on all the existing servers and not just the training server. This will allow to download the data files from the production servers.

Changes made:
- Add all the eligible server URL patterns to the `host_permissions` key in manifest.json file.
- Refactor background.js to use the server names from the manifest.json rather than hard-coding it at 2 different places.
- Update the README.md file to reflect the updated eligible servers to use this extension for.

Closes #15 