### PR TITLE
Fix page-action not defined error because of deprication

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -5,7 +5,7 @@
 
   "description": "",
 
-  "page_action": {
+  "action": {
     "default_icon": "icons/white_outline_download_icon.png"
   },
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
 
   "description": "",
 
-  "page_action": {
+  "action": {
     "default_icon": "icons/white_outline_download_icon.png"
   },
 


### PR DESCRIPTION
This PR fixes the issue of extension click not invoking the `onClick` handler. This happened because the `page_action` use is discontinued in manifest V3 for firefox as noted in the [migration guide](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/#developer-preview-changes).

Changes made:
- Replace the use of `browser.page_action.onClick` to `browser.action.onClick`